### PR TITLE
Use org-wide reusable workflow for actionlint

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,13 +1,24 @@
-name: reviewdog
-on: [pull_request]
+name: Lint workflow files
+
+on:
+  push:
+    paths:
+      - '.github/workflows/*.yml'
+      - '.github/workflows/*.yaml'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - '.github/workflows/*.yml'
+      - '.github/workflows/*.yaml'
+
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   actionlint:
-    name: runner / actionlint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: actionlint
-        uses: reviewdog/action-actionlint@v1.2.0
-        with:
-          fail_on_error: true
-          reporter: github-pr-review
+    uses: fac/shared-workflows/.github/workflows/actionlint.yml@main
+    secrets: inherit


### PR DESCRIPTION
 # What
Previously we added `actionlint` workflows to lots of repos:
- https://github.com/fac/dev-platform/issues/314

They trigger on every push to a PR branch, so most of the time this is unnecessary, as workflows are rarely updated. Really we only need to trigger `actionlint` when workflows are changed.

We're now looking to use org-wide reusable workflows that can be updated in one central place.

Dev-P ticket
 - https://github.com/fac/dev-platform/issues/1002
